### PR TITLE
Excluded GOG Notifications from hooked windows.

### DIFF
--- a/OriginSteamOverlayLauncher/WindowUtils.cs
+++ b/OriginSteamOverlayLauncher/WindowUtils.cs
@@ -132,6 +132,8 @@ namespace OriginSteamOverlayLauncher
                     // excluded windows
                     if (ProcessUtils.OrdinalContains("EasyAntiCheat_launcher", haystack))
                         return -1;
+                    else if (ProcessUtils.OrdinalContains("GOG Galaxy Notifications Renderer", haystack))
+                        return -1;
 
                     // initially try to resolve by looking up className and windowTitle
                     if (MatchWindowDetails("Epic Games Launcher", "UnrealWindow", _hWnd))


### PR DESCRIPTION
Hello @WombatFromHell,

Thanks for this tool.  I was facing an issue that after closing The Witcher.  OSOL would detect and hook onto the GOG Notification which indicated that my save game data had been synchronized.

```
[6/24/2021 9:39:57 PM] [MONITOR@witcher3] Process exited, attempting to reacquire within 15s: witcher3.exe
[6/24/2021 9:40:01 PM] [MONITOR@witcher3] Process acquired in 5.56s: GOG Galaxy Notifications Renderer.exe [26580]
```

OSOL would many times stay attached even after the notification disappeared and keep Steam Big Picture mode waiting for the "game" to close until I manually exited GOG Galaxy.

I was not 100% sure what the purpose of the function `DetectWindowType` was for but I found that it caught the window in
```
else if (WindowHasDetails(_hWnd) || IsWindow(_hWnd))
   result = 0; // catch all other obvious windows
```
To skip this I manually check for the notifier and return -1.

In the function `ValidateWMIProc` the result of 0 in `DetectWindowType` causes `bool hasDetails` to become `true`.

Additionally in `ValidateWMIProc` I believe that the first condition `(isValid && !avoidMatches && nameMatches && hasDetails)` in
```
return (isValid && !avoidMatches && nameMatches && hasDetails) ||
   (isValid && !avoidMatches && nameMatches) ||
   (isValid && !avoidMatches && hasDetails);
```
is redundant/not evaluated since the two following conditions are less restrictive.

Please let me know if I should make any different updates or if I should look elsewere to resolve the issue I had.